### PR TITLE
Feat/adguard home enhancements

### DIFF
--- a/templates/networking/docker_adguard/.gitignore
+++ b/templates/networking/docker_adguard/.gitignore
@@ -7,3 +7,5 @@ unbound/config.d/*
 !unbound/config.d/cachedb.conf
 !unbound/config.d/config.conf
 !unbound/config.d/*example*
+!unbound/*example*
+

--- a/templates/networking/docker_adguard/overlays/unbound.yml
+++ b/templates/networking/docker_adguard/overlays/unbound.yml
@@ -18,7 +18,7 @@ services:
       - adguardhome
 
   unbound:
-    image: klutchell/unbound
+    image: mvance/unbound:latest
     container_name: unbound
     hostname: unbound
     restart: unless-stopped

--- a/templates/networking/docker_adguard/overlays/unbound.yml
+++ b/templates/networking/docker_adguard/overlays/unbound.yml
@@ -8,7 +8,6 @@ networks:
         - subnet: 172.16.81.0/24
 
 volumes:
-  unbound_redis_data: {}
   unbound_config: {}
 
 services:
@@ -18,29 +17,11 @@ services:
     networks:
       - adguardhome
 
-  redis:
-    image: redis:latest
-    container_name: unbound-redis
-    hostname: redis
-    restart: unless-stopped
-    volumes:
-      - ${REDIS_DATA_DIR:-unbound_redis_data}:/data
-    networks:
-      - adguardhome
-    healthcheck:
-      test: "[ $$(redis-cli ping) = 'PONG' ]"
-      interval: 30s
-      timeout: 3s
-      retries: 3
-      start_period: 30s
-
   unbound:
     image: klutchell/unbound
     container_name: unbound
     hostname: unbound
     restart: unless-stopped
-    depends_on:
-      - redis
     volumes:
       - ${UNBOUND_CONFIG_DIR:-./unbound/config.d}:/etc/unbound/custom.conf.d:ro
     ports:

--- a/templates/networking/docker_adguard/scripts/run-adguard-unbound.sh
+++ b/templates/networking/docker_adguard/scripts/run-adguard-unbound.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v docker compose >&/dev/null; then
+  echo "[ERROR] docker compose is not installed" >&2
+  exit 1
+fi
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGH_ROOT=$(realpath -m "${THIS_DIR}/..")
+
+CWD=$(pwd); trap 'cd "$CWD"' EXIT
+MAIN_COMPOSE_FILE="${AGH_ROOT}/compose.yml"
+UNBOUND_COMPOSE_FILE="${AGH_ROOT}/overlays/unbound.yml"
+
+PULL="false"
+RECREATE="false"
+DRY_RUN="false"
+
+function usage() {
+  cat <<EOF
+Usage: ${0} [OPTIONS]
+
+Options:
+  -h, --help          Print this help menu
+  -p, -u, --pull      Pull new images
+  -r, -f, --recreate  Recreate containers with --force-recreate
+  --dry-run           Describe actions instead of taking them
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -u|-p|--pull)
+      PULL="true"
+      shift
+      ;;
+    -f|-r|--recreate)
+      RECREATE="true"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    *)
+      echo "[ERROR] Invalid arg: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+cd "${AGH_ROOT}"
+
+CMD="docker compose -f ${MAIN_COMPOSE_FILE} -f ${UNBOUND_COMPOSE_FILE}"
+
+if [[ "${RECREATE}" == "true" ]] && [[ "${PULL}" == "true" ]]; then
+  CMD_1="${CMD} pull"
+  CMD_2="${CMD} up -d --force-recreate"
+
+  CMD="${CMD_1} && ${CMD_2}"
+elif [[ "${RECREATE}" == "true" ]]; then
+  CMD="${CMD} up -d --force-recreate"
+elif [[ "${PULL}" == "true" ]]; then
+  CMD="${CMD} pull"
+else
+  CMD="${CMD} up -d"
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "[DRY RUN] Would run command:"
+  echo "  ${CMD}"
+  echo
+else
+  echo "Running command:"
+  echo "  ${CMD}"
+  echo
+
+  if ! eval "${CMD}" 2>&1; then
+    echo "[ERROR] Docker Compose command failed" >&2
+    exit 1
+  fi
+fi

--- a/templates/networking/docker_adguard/unbound/config.d/cachedb.conf
+++ b/templates/networking/docker_adguard/unbound/config.d/cachedb.conf
@@ -1,7 +1,0 @@
-server:
-  module-config: "validator cachedb iterator"
-cachedb:
-  backend: "redis"
-  redis-server-host: redis
-  redis-server-port: 6379
-  redis-expire-records: yes

--- a/templates/networking/docker_adguard/unbound/config.d/config.conf
+++ b/templates/networking/docker_adguard/unbound/config.d/config.conf
@@ -1,4 +1,14 @@
 server:
+  ## Set to 0 for silent
+  verbosity: 1
+  ## Do not leave this enabled
+  log-queries: no
+  ## Log upstream failures
+  log-servfail: yes
+  ## Do not leave this enabled. Logs
+  #  upstream events locally
+  log-local-actions: no
+
   interface: 0.0.0.0
   port: 53
 

--- a/templates/networking/docker_adguard/unbound/config.d/config.conf
+++ b/templates/networking/docker_adguard/unbound/config.d/config.conf
@@ -1,52 +1,31 @@
 server:
   interface: 0.0.0.0
   port: 53
-  do-ip6: no
+
   do-ip4: yes
+  do-ip6: no
   do-udp: yes
   do-tcp: yes
+
   num-threads: 4
+
   hide-identity: yes
   hide-version: yes
-  harden-glue: yes
-  harden-dnssec-stripped: yes
-  harden-referral-path: yes
-  use-caps-for-id: yes
-  harden-algo-downgrade: no
+
   qname-minimisation: yes
   aggressive-nsec: yes
-  rrset-roundrobin: yes
 
-  cache-min-ttl: 300
-  ## Default: 14400 (4 hours)
-  #  1 day = 86400
-  #  2 days = 172800
-  #  3 days = 86400
-  cache-max-ttl: 86400
-
-  msg-cache-slabs: 8
-  rrset-cache-slabs: 8
-  infra-cache-slabs: 8
-  key-cache-slabs: 8
-
-  serve-expired: yes
-  serve-expired-ttl: 3600
-
-  edns-buffer-size: 1232
   prefetch: yes
   prefetch-key: yes
-  target-fetch-policy: "3 2 1 1 1"
-  unwanted-reply-threshold: 10000000
 
-  rrset-cache-size: 256m
+  edns-buffer-size: 1232
+
+  cache-min-ttl: 300
+  cache-max-ttl: 86400
+
   msg-cache-size: 128m
-  # so-rcvbuf: 1m
+  rrset-cache-size: 256m
+
   so-rcvbuf: 0
   so-sndbuf: 0
 
-  private-address: 192.168.0.0/16
-  private-address: 169.254.0.0/16
-  private-address: 172.16.0.0/12
-  private-address: 10.0.0.0/8
-  private-address: fd00::/8
-  private-address: fe80::/10

--- a/templates/networking/docker_adguard/unbound/config.d/controld-forward.conf.example
+++ b/templates/networking/docker_adguard/unbound/config.d/controld-forward.conf.example
@@ -1,4 +1,0 @@
-forward-zone:
-  name: "."
-  forward-addr: <controld-ip-1>
-  forward-addr: <controld-id-2>

--- a/templates/networking/docker_adguard/unbound/config.d/nextdns-forward.conf.example
+++ b/templates/networking/docker_adguard/unbound/config.d/nextdns-forward.conf.example
@@ -1,8 +1,0 @@
-forward-zone:
-    name: "."
-    forward-tls-upstream: yes
-    
-    # Encrypted NextDNS DoT first (primary + backup anycast)
-    forward-addr: 45.90.28.0@853#YOUR_ID.dns1.nextdns.io
-    forward-addr: 45.90.30.0@853#YOUR_ID.dns2.nextdns.io
-    forward-addr: 2a07:a8c0::@853#YOUR_ID.dns1.nextdns.io

--- a/templates/networking/docker_adguard/unbound/example-configs/forward.conf.example
+++ b/templates/networking/docker_adguard/unbound/example-configs/forward.conf.example
@@ -1,0 +1,15 @@
+forward-zone:
+  name: "."
+  forward-tls-upstream: yes
+
+  ## DNS-over-TLS
+
+  ## ControlD
+  # forward-addr: <controld-dns-over-tls-ip>
+  # forward-addr: <controld-dns-over-tls-ip>
+
+  ## NextDNS
+  # forward-addr: <nextdns-anycast-addr>@853#<nextdns-configuration-or-profile-id>.dns1.nextdns.io
+  # forward-addr: <nextdns-anycast-addr>@853#<nextdns-configuration-or-profile-id>.dns2.nextdns.io
+  # forward-addr: 2a07:a8c0::@853#<nextdns-configuration-or-profile-id>.dns1.nextdns.io
+

--- a/templates/networking/docker_adguard/unbound/example-configs/forward.conf.example
+++ b/templates/networking/docker_adguard/unbound/example-configs/forward.conf.example
@@ -1,3 +1,6 @@
+server:
+  module-config: "validator iterator"
+
 forward-zone:
   name: "."
   forward-tls-upstream: yes


### PR DESCRIPTION
Refactor adguard + unbound stack.

- Remove redis from configuration. It's an unnecessary dependency for home use.
- Switch to the [`mvance/unbound` image](https://hub.docker.com/r/mvance/unbound/) and update Unbound's `config.conf`.
- Move Unbound config examples into `example-config/` dir.
